### PR TITLE
fix: treat RDAP 404 responses as "domain not found" instead of failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,20 @@ export async function lookup(
       for (const base of bases) {
         tried.push(base);
         try {
-          const { json } = await fetchRdapDomain(domain, base, opts);
+          const { json, notFound } = await fetchRdapDomain(domain, base, opts);
+
+          // HTTP 404 = domain not registered
+          if (notFound) {
+            const record: DomainRecord = {
+              domain,
+              tld,
+              isRegistered: false,
+              rdapServers: tried,
+              source: "rdap",
+            };
+            return { ok: true, record };
+          }
+
           const rdapEnriched = await fetchAndMergeRdapRelated(
             domain,
             json,

--- a/src/rdap/client.ts
+++ b/src/rdap/client.ts
@@ -4,14 +4,26 @@ import { resolveFetch } from "../lib/fetch";
 import type { LookupOptions } from "../types";
 
 /**
+ * Result of an RDAP fetch operation.
+ * - `json` contains the RDAP response if successful
+ * - `notFound` is true if the server returned 404 (domain not registered)
+ */
+export interface RdapFetchResult {
+  url: string;
+  json: unknown;
+  notFound?: boolean;
+}
+
+/**
  * Fetch RDAP JSON for a domain from a specific RDAP base URL.
- * Throws on HTTP >= 400 (includes RDAP error JSON payloads).
+ * Returns `{ notFound: true }` for HTTP 404 (domain not registered).
+ * Throws on other HTTP errors (5xx, network errors, etc.).
  */
 export async function fetchRdapDomain(
   domain: string,
   baseUrl: string,
   options?: LookupOptions,
-): Promise<{ url: string; json: unknown }> {
+): Promise<RdapFetchResult> {
   const url = new URL(
     `domain/${encodeURIComponent(domain)}`,
     baseUrl,
@@ -26,6 +38,11 @@ export async function fetchRdapDomain(
     options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     "RDAP lookup timeout",
   );
+  // HTTP 404 = domain not found (not registered)
+  // Per RFC 9083, RDAP servers return 404 for objects that don't exist
+  if (res.status === 404) {
+    return { url, json: null, notFound: true };
+  }
   if (!res.ok) {
     const bodyText = await res.text();
     throw new Error(`RDAP ${res.status}: ${bodyText.slice(0, 500)}`);


### PR DESCRIPTION
Hi there. When an RDAP server returns HTTP 404 for a non-existent domain, rdapper should return `{ ok: true, record: { isRegistered: false } }` instead of treating it as a service failure.

Per https://datatracker.ietf.org/doc/html/rfc9083#section-8, RDAP servers return 404 for objects that don't exist. This is a valid response indicating the domain is not registered, not an error.

```ts
const result = await lookup('nonexistent-domain-12345.gallery', { rdapOnly: true });
// Before: { ok: false, error: "RDAP not available or failed for TLD 'gallery'..." }
// After:  { ok: true, record: { isRegistered: false, source: "rdap", ... } }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain lookups now correctly identify non-existent domains and report accurate registration status, preventing unnecessary secondary lookup attempts.

* **Tests**
  * Added comprehensive test suite for non-existent domain scenarios to validate proper handling and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->